### PR TITLE
Fix patchfinder build under vcpkg include layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@ mo2-fomod-plus.7z
 docs/
 tests/build
 build/
+build-*/
+dist/
+CMakeUserPresets.json
 compile_commands.json

--- a/patchfinder/CMakeLists.txt
+++ b/patchfinder/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(
         ${CMAKE_CURRENT_SOURCE_DIR}/../share
         ${CMAKE_CURRENT_SOURCE_DIR}/../share/FOMODData
         ${CMAKE_CURRENT_SOURCE_DIR}/../share/xml
+        ${MO2_UIBASE_INCLUDE_DIRS}
         ${MO2_ARCHIVE_INCLUDE_DIRS}
         ${RESOURCE_DIR}
 )
@@ -39,6 +40,6 @@ if (MSVC)
     )
 endif ()
 
-target_link_libraries(fomod_plus_patch_finder PRIVATE pugixml nlohmann_json::nlohmann_json)
+target_link_libraries(fomod_plus_patch_finder PRIVATE mo2::uibase mo2::archive pugixml nlohmann_json::nlohmann_json)
 mo2_configure_plugin(fomod_plus_patch_finder WARNINGS OFF PRIVATE_DEPENDS archive)
 mo2_install_target(fomod_plus_patch_finder)


### PR DESCRIPTION
## What

- `patchfinder/CMakeLists.txt`: add `${MO2_UIBASE_INCLUDE_DIRS}` to the target include dirs and link `mo2::uibase` (mirroring `scanner`/`installer`).
- `.gitignore`: ignore `build-*/`, `dist/`, and `CMakeUserPresets.json`.

## Why

patchfinder relied on `mo2_configure_plugin` to pull in uibase transitively. That works against a source-tree MO2 layout, but under the vcpkg/installed include layout AutoMoc can't find `iplugintool.h`'s `Q_DECLARE_INTERFACE`, so the build fails with:

```
FomodPlusPatchFinder.h: error: Undefined interface
```

on the `Q_INTERFACES(MOBase::IPlugin MOBase::IPluginTool)` line. Adding the explicit uibase include dir + link makes patchfinder consistent with the other two plugins and fixes the build. Surfaced while building against MO2 2.5.3 beta12.